### PR TITLE
17388: Remove TEMP_PAT usage

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -57,7 +57,6 @@ jobs:
         fileName: "*linux-amd64*"
         extract: true
         out-file-path: "amalgam/lib/linux/amd64"
-        token: ${{ secrets.TEMP_PAT }}
 
     - name: Download Amalgam linux-arm64
       if: matrix.plat == 'manylinux_2_29_aarch64' || matrix.plat == 'any'
@@ -68,7 +67,6 @@ jobs:
         fileName: "*linux-arm64.tar.gz"
         extract: true
         out-file-path: "amalgam/lib/linux/arm64"
-        token: ${{ secrets.TEMP_PAT }}
 
     - name: Download Amalgam linux-arm64_8a
       if: matrix.plat == 'manylinux_2_29_aarch64' || matrix.plat == 'any'
@@ -79,7 +77,6 @@ jobs:
         fileName: "*linux-arm64_8a*"
         extract: true
         out-file-path: "amalgam/lib/linux/arm64_8a"
-        token: ${{ secrets.TEMP_PAT }}
 
     - name: Download Amalgam darwin-amd64
       if: matrix.plat == 'macosx_11_0_x86_64' || matrix.plat == 'any'
@@ -90,7 +87,6 @@ jobs:
         fileName: "*darwin-amd64*"
         extract: true
         out-file-path: "amalgam/lib/darwin/amd64"
-        token: ${{ secrets.TEMP_PAT }}
 
     - name: Download Amalgam darwin-arm64
       if: matrix.plat == 'macosx_11_0_arm64' || matrix.plat == 'any'
@@ -101,7 +97,6 @@ jobs:
         fileName: "*darwin-arm64*"
         extract: true
         out-file-path: "amalgam/lib/darwin/arm64"
-        token: ${{ secrets.TEMP_PAT }}
 
     - name: Download Amalgam windows-amd64
       if: matrix.plat == 'win_amd64' || matrix.plat == 'any'
@@ -112,7 +107,6 @@ jobs:
         fileName: "*windows-amd64*"
         extract: true
         out-file-path: "amalgam/lib/windows/amd64"
-        token: ${{ secrets.TEMP_PAT }}
 
     - name: Clean up dir
       run: |

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -30,7 +30,6 @@ jobs:
           fileName: "*linux-amd64*"
           extract: true
           out-file-path: "amalgam/lib/linux/amd64"
-          token: ${{ secrets.TEMP_PAT }}
 
       - name: Clean up dir
         run: |


### PR DESCRIPTION
TEMP_PAT is no longer needed to download amalgam release artifacts.