### PR TITLE
17482: Package version.json into site-packages

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -111,7 +111,9 @@ jobs:
     - name: Clean up dir
       run: |
         pwd
+        cp version.json amalgam/lib/version.json
         cd amalgam/lib
+        sed -i 's/dependencies/version/g' version.json
         find . -type d -name lib -exec sh -c 'mv {}/* "$(dirname {})"' \;
 
     - name: Build wheels

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,6 @@
 include *.md
-include *.json
 include LICENSE.txt
+global-include *.json
 global-include *.so
 global-include *.dylib
 global-include *.dll


### PR DESCRIPTION
Include `version.json` in the `amalgam/lib` directory when packaging.