### PR TITLE
17599: Allow users to specify platform architecture

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "amalgam": "44.0.1"
+    "amalgam": "44.0.2"
   }
 }


### PR DESCRIPTION
Added `arch` as an optional input to `Amalgam` that, if provided, will be used to generate the embedded shared object location path instead of `platform.machine()`.

Also increased the Amalgam version in `version.json`.