### PR TITLE
18641: Removes nonexistent requirements-dev.in reference in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,9 +51,6 @@ repository = "https://github.com/howsoai/amalgam-lang-py"
 [tool.setuptools]
 packages = ["amalgam"]
 
-[tool.setuptools.dynamic]
-optional-dependencies.dev = { file = ["requirements-dev.in"]}
-
 [tool.isort]
 profile = "google"
 known_first_party = ["howso"]


### PR DESCRIPTION
Removes a dynamic optional dependency in `requirements-dev.in` that was removed some time ago. Dev requirements are specified already in `pyproject.toml`.