### PR TITLE
19165: Adds `exist_ok=True` to trace directory creation call

### DIFF
--- a/amalgam/api.py
+++ b/amalgam/api.py
@@ -111,7 +111,7 @@ class Amalgam:
                     execution_trace_dir).expanduser().absolute()
             # Create the trace directory if needed
             if not self.execution_trace_dir.exists():
-                self.execution_trace_dir.mkdir(parents=True)
+                self.execution_trace_dir.mkdir(parents=True, exist_ok=True)
 
             # increment a counter on the file name, if file already exists..
             self.execution_trace_filepath = Path(


### PR DESCRIPTION
Adding `exist_ok=True` on the `mkdir` call that creates the directory for the tracefile.

We believe this may be the cause of some test failures where a race condition exists where multiple processes find the directory does not exist, then one creates the directory before the rest. This means that when the following processes attempt to create the directory, it already existed. Adding this flag should prevent these exceptions.