### PR TITLE
19404: Updates token permissions for release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -290,6 +290,8 @@ jobs:
       - pytest-macos-3-11-mt
       - pytest-windows-3-11-mt
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
 
     - name: Download Artifacts


### PR DESCRIPTION
Required for trusted publishing to PyPi. Followup bugfix to #68.