### PR TITLE
19404: Adds publishing environment setting to release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -290,6 +290,8 @@ jobs:
       - pytest-macos-3-11-mt
       - pytest-windows-3-11-mt
     runs-on: ubuntu-latest
+    environment:
+      name: PyPi
     permissions:
       id-token: write
     steps:


### PR DESCRIPTION
Another follow-up to #68 to support PyPi trusted publishing.