### PR TITLE
20545: Reenables test_bulk_operations unit test

### DIFF
--- a/amalgam/test/test_standalone.py
+++ b/amalgam/test/test_standalone.py
@@ -24,7 +24,7 @@ def amalgam_lib():
                    execution_trace_dir='./traces/', trace=True)
 
 
-@pytest.mark.skipif(True, reason="Pending bugfix") # TODO: 20545
+@pytest.mark.skipif(not is_amalgam_installed, reason="Amalgam is not installed")
 def test_bulk_operations(amalgam_lib):
     amalgam_lib.reset_trace('test_bulk_operations.trace')
     assert bulk_operations(amalgam_lib)


### PR DESCRIPTION
This test can be re-enabled since the faulty endpoints being called as part of the test were removed in #98. 