### PR TITLE
21160: Adds retries to PyPi publish, reorders release steps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -341,6 +341,16 @@ jobs:
           find ./tmp -type f -name '*.tar.gz' -exec mv -t ./dist {} +
           ls ./dist
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - uses: Wandalen/wretry.action@master
+        with:
+          action: pypa/gh-action-pypi-publish@release/v1
+          attempt_limit: 3
+
       - name: Create Release
         uses: ncipollo/release-action@v1
         with:
@@ -352,11 +362,3 @@ jobs:
           makeLatest: legacy
           artifacts: "dist/*"
           artifactContentType: application/gzip
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
-      - name: Publish distribution to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
The step in the release workflow that publishes to PyPi often fails on the first attempt and requires a retry. However, the GitHub release happens _before_ the PyPi release currently, so someone has to go back and delete the GitHub release and tag and then retry. This reorders the steps to do the GitHub release _after_ a successful PyPi release, and also adds a retry wrapper to the PyPi release (3 attempts).