### PR TITLE
21113: Conditions GitHub release publishing on successful PyPi upload

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -318,6 +318,7 @@ jobs:
       - pytest-linux-3-12-mt
       - pytest-macos-3-12-mt
       - pytest-windows-3-12-mt
+      - publish
     runs-on: ubuntu-latest
     environment:
       name: pypi


### PR DESCRIPTION
Follow-up to #111 which re-ordered the release steps.