### PR TITLE
22211: Build 55.1.2 Release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        plat: [manylinux_2_29_x86_64, manylinux_2_29_aarch64, macosx_12_0_x86_64, macosx_12_0_arm64, win_amd64, any]
+        plat: [manylinux_2_28_x86_64, manylinux_2_29_x86_64, manylinux_2_29_aarch64, macosx_12_0_x86_64, macosx_12_0_arm64, win_amd64, any]
 
     steps:
 
@@ -77,7 +77,29 @@ jobs:
       run: |
         run_id=$(printf "%s" '${{ needs.metadata.outputs.upstream-details }}' | jq -r '."amalgam".run_id')
         run_type=$(printf "%s" '${{ needs.metadata.outputs.upstream-details }}' | jq -r '."amalgam".run_type')
-        gh $run_type download -D amalgam/lib/linux/amd64 -R "howsoai/amalgam" -p "*linux-amd64*" "$run_id"
+        # Release artifacts will have a .tar.gz postfix while branch/PR build artifacts will not
+        if [[ "$run_type" == "release" ]]; then
+          gh $run_type download -D amalgam/lib/linux/amd64 -R "howsoai/amalgam" -p "amalgam-*-linux-amd64.tar.gz" "$run_id"
+        else
+          gh $run_type download -D amalgam/lib/linux/amd64 -R "howsoai/amalgam" -p "amalgam-*-linux-amd64" "$run_id"
+        fi
+        # Needed because release/non-release downloads are different structure
+        cd amalgam/lib/linux/amd64 && if [ ! -f *.tar.gz ]; then mv */*.tar.gz ./; fi && tar -xvzf *.tar.gz
+
+    - name: Download Amalgam linux-amd64-228
+      # Linux version that supports GLIBC 2.28+, most users should use 2.29+ (above)
+      # This specifically does NOT run on the "any" platform target. 
+      if: matrix.plat == 'manylinux_2_28_x86_64'
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        run_id=$(printf "%s" '${{ needs.metadata.outputs.upstream-details }}' | jq -r '."amalgam".run_id')
+        run_type=$(printf "%s" '${{ needs.metadata.outputs.upstream-details }}' | jq -r '."amalgam".run_type')
+        if [[ "$run_type" == "release" ]]; then
+          gh $run_type download -D amalgam/lib/linux/amd64 -R "howsoai/amalgam" -p "amalgam-*-linux-amd64-228.tar.gz" "$run_id"
+        else
+          gh $run_type download -D amalgam/lib/linux/amd64 -R "howsoai/amalgam" -p "amalgam-*-linux-amd64-228" "$run_id"
+        fi
         # Needed because release/non-release downloads are different structure
         cd amalgam/lib/linux/amd64 && if [ ! -f *.tar.gz ]; then mv */*.tar.gz ./; fi && tar -xvzf *.tar.gz
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -300,6 +300,9 @@ jobs:
 
     - name: Publish [PyPi]
       uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        # Experimental feature not yet compatible with our workflow
+        attestations: False
 
   generate-changelog:
     if: inputs.build-type == 'release'

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "amalgam": "55.1.1"
+    "amalgam": "55.1.2"
   }
 }


### PR DESCRIPTION
- Add support for GLIBC 2.28 / Oracle Linux 8.x
- Build with Amalgam release 55.1.2