### PR TITLE
24254: refactor trace file output

### DIFF
--- a/amalgam/test/test_standalone.py
+++ b/amalgam/test/test_standalone.py
@@ -3,7 +3,6 @@ import logging
 import json
 from uuid import uuid4
 import os
-import random
 
 import pytest
 
@@ -14,7 +13,7 @@ _logger = logging.getLogger(__name__)
 
 amlg_postfix = os.getenv('AMALGAM_LIBRARY_POSTFIX', '-st')
 amlg_path, _ = Amalgam._get_library_path(library_postfix=amlg_postfix)
-_logger.debug(f'Amalgam path: ', {amlg_path})
+_logger.debug('Amalgam path: %s', amlg_path)
 is_amalgam_installed = amlg_path.exists()
 
 


### PR DESCRIPTION
Make the trace file be binary.  Where Amalgam requests and responses
include raw bytes, include these directly in the trace file without
attempting to change their types.  Include both the JSON result and
log entry in the trace file for ExecuteEntityJsonLogged().