### PR TITLE
25660: Updates Amalgam version, MAJOR

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "amalgam": "80.0.5"
+    "amalgam": "81.0.1"
   }
 }


### PR DESCRIPTION
Bumps the bundled Amalgam engine `80.0.5` → `81.0.1`.

MAJOR — 81.0.0 is a major engine release (mutate-opcode overhaul, sandboxing consolidation that removes `call_sandboxed`), and 81.0.1 adds the mutate string-leak fix.

Single-line change to `version.json`.